### PR TITLE
Drivers now depend on NG

### DIFF
--- a/c2-01-generic-variables.tf
+++ b/c2-01-generic-variables.tf
@@ -9,11 +9,5 @@ variable "aws_region" {
 variable "environment" {
   description = "Environment Variable used as a prefix"
   type        = string
-  default     = "sanbox"
-}
-# Business Division
-variable "business_divsion" {
-  description = "Business Division in the large organization this Infrastructure belongs"
-  type        = string
-  default     = "home"
+  default     = "sandbox"
 }

--- a/c2-02-local-values.tf
+++ b/c2-02-local-values.tf
@@ -1,14 +1,9 @@
 # Define Local Values in Terraform
 locals {
-  owners      = var.business_divsion
   environment = var.environment
   name        = "${var.environment}"
-  #name        = "${var.business_divsion}-${var.environment}"
-  #name       = "${local.owners}-${local.environment}"
   common_tags = {
-    owners      = local.owners
-    environment = local.environment
+      environment = local.environment
   }
-  eks_cluster_name = "EKS_Sandbox" #<-- Setting to EKS_Sandbox for now...
-  #eks_cluster_name = "${local.name}-${var.cluster_name}"  
+  eks_cluster_name = "ekssandbox"
 } 

--- a/c5-06-eks-cluster.tf
+++ b/c5-06-eks-cluster.tf
@@ -1,6 +1,5 @@
 # Create AWS EKS Cluster
 resource "aws_eks_cluster" "eks_cluster" {
-  #name      = "${local.name}-${var.cluster_name}"
   name      = "${var.cluster_name}"
   role_arn  = aws_iam_role.eks_master_role.arn
   version   = var.cluster_version

--- a/c6-01-additional-cluster-drivers.tf
+++ b/c6-01-additional-cluster-drivers.tf
@@ -6,6 +6,8 @@ resource "aws_eks_addon" "aws-ebs-csi-driver" {
   addon_name                  = "aws-ebs-csi-driver"
   addon_version               = "v1.23.0-eksbuild.1"
   resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [aws_eks_node_group.eks_ng_public]
 }
 
 # Adding CoreDNS
@@ -15,4 +17,6 @@ resource "aws_eks_addon" "aws-coredns-driver" {
   addon_name                  = "coredns"
   addon_version               = "v1.10.1-eksbuild.4"
   resolve_conflicts_on_update = "PRESERVE"
+
+  depends_on = [aws_eks_node_group.eks_ng_public]
 }


### PR DESCRIPTION
EBS and CoreDNS drivers should now wait for the nodegroup to be created, hopefully avoiding failures - Untested due to a delete hang issue on AWS side.

Minor variable  changes and comment cleanup.